### PR TITLE
feat(api): add bindToImplements method to bind a class to its interface implementations

### DIFF
--- a/example/app.ts
+++ b/example/app.ts
@@ -7,6 +7,7 @@ import { MyBrokenOperator } from './impl/MyBrokenOperator';
 import { MyOperator } from './impl/MyOperator';
 import { MyTest } from './impl/MyTest';
 import { Test } from './impl/Test';
+import { FileWriterReader } from './impl/FileWriterReader';
 import { App } from './impl/App';
 
 const container = new Container();
@@ -14,5 +15,7 @@ container.bind(InterfaceSymbol<IBird>(), Crow);
 container.bindToConstant(InterfaceSymbol<IOperator>(), new MyBrokenOperator());
 container.bindToConstant(InterfaceSymbol<IOperator>(), new MyOperator());
 container.bind(Test, MyTest);
+
+container.bindToImplements(FileWriterReader);
 
 container.resolve(App);

--- a/example/impl/App.ts
+++ b/example/impl/App.ts
@@ -1,8 +1,10 @@
 import { IBird } from "../models/IBird";
 import { Test } from "./Test";
+import { IFileWriter } from "models/IFileWriter";
+import { IFileReader } from "models/IFileReader";
 
 export class App {
-  constructor(bird: IBird, test: Test) {
+  constructor(bird: IBird, test: Test, reader: IFileReader, writer: IFileWriter) {
     if (bird.canFly()) {
       console.log("Bird can fly");
     } else {
@@ -10,5 +12,8 @@ export class App {
     }
 
     test.say("Amy");
+
+    console.log("read", reader.read("MyFile.txt"));
+    writer.write("nothere.json", "ANANANAN");
   }
 }

--- a/example/impl/FileWriterReader.ts
+++ b/example/impl/FileWriterReader.ts
@@ -1,0 +1,21 @@
+import { IFileReader } from "../models/IFileReader";
+import { IFileWriter } from "../models/IFileWriter";
+import { IOperator } from "models/IOperator";
+
+export class FileWriterReader implements IFileReader, IFileWriter {
+  private _operator: IOperator;
+  private _id: number;
+
+  public constructor(operator: IOperator) {
+    this._operator = operator;
+    this._id = Math.random()*10000;
+  }
+
+  public read(file: string): string {
+    return this._id + ": " + file + " + content: " + this._operator.add(2, 3);
+  }
+  
+  public write(file: string, content: string): void {
+    console.log(this._id + ": Data written to " + file + ": " + content);
+  }
+}

--- a/example/models/IFileReader.ts
+++ b/example/models/IFileReader.ts
@@ -1,0 +1,3 @@
+export interface IFileReader {
+  read(file: string): string;
+}

--- a/example/models/IFileWriter.ts
+++ b/example/models/IFileWriter.ts
@@ -1,0 +1,3 @@
+export interface IFileWriter {
+  write(file: string, content: string): void;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-di-transformer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "author": {
     "name": "Jeppe Rune Mortensen",

--- a/src/api.ts
+++ b/src/api.ts
@@ -57,7 +57,7 @@ export class Container {
   }
 
   public bind<T>(serviceIdentifier: ServiceIdentifier<T>, constructor: Newable<T>, params: any[] = []): void {
-    let entries = this._map.get(serviceIdentifier) || [];
+    const entries = this._map.get(serviceIdentifier) || [];
     entries.push({
       kind: 'newable',
       newable: constructor,
@@ -68,13 +68,34 @@ export class Container {
   }
 
   public bindToConstant<T>(serviceIdentifier: ServiceIdentifier<T>, constant: any): void {
-    let entries = this._map.get(serviceIdentifier) || [];
+    const entries = this._map.get(serviceIdentifier) || [];
     entries.push({
       kind: 'constant',
       value: constant
     });
 
     this._map.set(serviceIdentifier, entries);
+  }
+
+  /**
+   * Bind the implementations of the class to the class.
+   * @param constructor 
+   * @param params 
+   * @param serviceIdentifiers 
+   */
+  public bindToImplements<T>(constructor: Newable<T>, params: any[] = [], serviceIdentifiers: ServiceIdentifier<T>[] = []) {
+    const entry = {
+      kind: 'newable',
+      newable: constructor,
+      params
+    } as IContainerNewable;
+
+    for (const serviceIdentifier of serviceIdentifiers) {
+      const entries = this._map.get(serviceIdentifier) || [];
+      entries.push(entry);
+
+      this._map.set(serviceIdentifier, entries);
+    }
   }
 
   public resolve<T>(service: Newable<T>, params: any[] = []): T {


### PR DESCRIPTION
Example usage:
```TypeScript
interface IReader {
  read(): string;
}

interface IWriter {
  write(text: string): void;
}

class File implements IReader, IWriter {
  read(): string {
    return "content of file";
  }

  write(text: string): void {
    // do something
  }
}

class App {
  constructor(reader: IReader, writer: IWriter) {
    console.log(reader.read());
    writer.write("Writing some stuff");
  }
}

// config
const container = new Container();

// Creates a new instance of File and binds it to both IReader and IWriter
container.bindToImplements(File);

container.resolve(App);
```